### PR TITLE
ャュョを含むケースを考慮

### DIFF
--- a/check-haiku-v2/check-haiku-v2.php
+++ b/check-haiku-v2/check-haiku-v2.php
@@ -20,7 +20,10 @@ function parseLine(array $parsed, int $limit, int $index): array
         if (!array_key_exists($index, $parsed)) {
             break;
         }
-        $count += mb_strlen($parsed[$index]->feature[8]);
+        $current = $parsed[$index]->feature[8];
+        $count += mb_strlen($current);
+        // ャュョについては直前の音にくっつくため、その分音数を減らす
+        $count -= preg_match_all('/[ャュョ]/u', $current);
         $original .= $parsed[$index]->feature[6];
         $yomi .= $parsed[$index]->feature[8];
         $index++;


### PR DESCRIPTION
例えば「ちょうちょ」という単語がある場合に、単純な文字数カウント (mb_strlen) だと5文字になるが、
実際の音の数 (モーラの数) で判定したいため、「ちょうちょ」は「ちょ」「う」「ちょ」で3音としたい。

「切手」などは「き」「っ」「て」で3音で大丈夫。「ー」も同様なので、「ャュョ」のケースのみ気にかける